### PR TITLE
Makes suggester more conservative

### DIFF
--- a/src/brain/Guess.cpp
+++ b/src/brain/Guess.cpp
@@ -121,6 +121,6 @@ double Guess::estimateRemainingSteps(double remainingEntropy) {
   // An experimental value
   // y = -0.0095x2 + 0.305x + 1.1094
   double x = max<double>(0, remainingEntropy);
-  return -0.0095 * x * x + 0.305 * x + 1.1094;
+  return -0.0095 * x * x + 0.305 * x + 0.1094;
 }
 }; // namespace wordle


### PR DESCRIPTION
Uniformly decreasing estimateRemainingSteps(entropy) will make the agent more likely to maximize information gain rather than try to guess the answer in one step.

This fixes "sates" to take only 5 steps: `tares -> humpf -> badge -> nates -> sates` -- but it may increase the mean number of steps for *all* words. There seems to be a tradeoff between reducing % of failures (> 6 steps) and reducing mean number of steps. There may be a sweet spot for the function that makes the % of failures 0 while still having a low number of steps (this will require some experimentation).

Btw thanks for sharing this interesting problem with me! It was a great learning experience :)